### PR TITLE
Unbreak ambient display while Heads up is disabled

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -7442,7 +7442,7 @@ public class StatusBar extends SystemUI implements DemoMode,
 
         }
 
-        if (!mUseHeadsUp || isDeviceInVrMode() || (mLessBoringHeadsUp &&
+        if (!mUseHeadsUp && !isDozing() || isDeviceInVrMode() || (mLessBoringHeadsUp &&
                 (!alwaysHeadsUpForDialer && !alwaysHeadsUpForMessaging))) {
             if (DEBUG) Log.d(TAG, "No peeking: no huns or vr mode or less boring headsup enabled");
             return false;


### PR DESCRIPTION
Google tied in heads up with ambient display and so if you disabled heads up,
you would only see a blank screen with LED pulsing. This commit fixes that!

XOS Edits: Adapt to our setup.

Change-Id: I2a32063e29d4ea434b9504c4dd79bcaae0f411bd
Signed-off-by: Harsh Shandilya <msfjarvis@gmail.com>